### PR TITLE
Use a symlink on non-Windows OS

### DIFF
--- a/inc/WpStash.php
+++ b/inc/WpStash.php
@@ -143,7 +143,11 @@ class WpStash
 
         $target = WP_CONTENT_DIR . DIRECTORY_SEPARATOR . $this->dropinName;
         if (! file_exists($target)) {
-            copy($this->dropinPath, $target);
+            if ('WIN' === strtoupper(substr(PHP_OS, 0, 3))) {
+                copy($this->dropinPath, $target);
+            } else {
+                symlink($target, $this->dropinPath);
+            }
         }
 
         if (is_admin()) {

--- a/inc/WpStash.php
+++ b/inc/WpStash.php
@@ -146,7 +146,7 @@ class WpStash
             if ('WIN' === strtoupper(substr(PHP_OS, 0, 3))) {
                 copy($this->dropinPath, $target);
             } else {
-                symlink($target, $this->dropinPath);
+                symlink($this->dropinPath, $target);
             }
         }
 


### PR DESCRIPTION
@Biont `object-cache.php` is meant to be a symbolic link only.