### PR TITLE
Add new env variable WP_STASH_RUNNABLE

### DIFF
--- a/src/WpStash.php
+++ b/src/WpStash.php
@@ -15,6 +15,10 @@ use Stash\Pool;
 final class WpStash
 {
 
+    const SCHEDULED_PURGE_HOOK = 'inpsyde.wp-stash.scheduled-purge';
+
+    const DEFAULT_DROPIN_PATH = '/../dropin/object-cache.php';
+
     /**
      * @var Config
      */
@@ -52,7 +56,7 @@ final class WpStash
         static $instance;
         if (! $instance) {
             $config = ConfigBuilder::create();
-            $instance = new self(__DIR__.'/../dropin/object-cache.php', $config);
+            $instance = new self(__DIR__ . self::DEFAULT_DROPIN_PATH, $config);
             $instance->init();
         }
 
@@ -151,13 +155,16 @@ final class WpStash
         }
 
         add_action('init', function () {
+            add_action(
+                self::SCHEDULED_PURGE_HOOK,
+                [$this, 'purge']
+            );
 
-            $scheduledPurgeHook = 'inpsyde.wp-stash.scheduled-purge';
-
-            add_action($scheduledPurgeHook, [$this, 'purge']);
-
-            if (! wp_next_scheduled($scheduledPurgeHook)) {
-                wp_schedule_single_event(time() + $this->config->purgeInterval(), $scheduledPurgeHook);
+            if (!wp_next_scheduled(self::SCHEDULED_PURGE_HOOK)) {
+                wp_schedule_single_event(
+                    time() + $this->config->purgeInterval(),
+                    self::SCHEDULED_PURGE_HOOK
+                );
             }
         });
 

--- a/wp-stash.php
+++ b/wp-stash.php
@@ -17,4 +17,18 @@ if (!class_exists(WpStash::class) && is_readable(__DIR__.'/vendor/autoload.php')
     require_once __DIR__.'/vendor/autoload.php';
 }
 
+if (isset($_ENV['WP_STASH_RUNNABLE']) && $_ENV['WP_STASH_RUNNABLE'] === "false") {
+    // Remove linked dropin file
+    $name = basename(__DIR__ . WpStash::DEFAULT_DROPIN_PATH);
+    $target = WP_CONTENT_DIR.DIRECTORY_SEPARATOR.$name;
+
+    if (!is_link($target) || !file_exists($target)) {
+        return;
+    }
+
+    unlink($target);
+
+    return;
+}
+
 class_exists(WpStash::class) && WpStash::instance();


### PR DESCRIPTION
The purpose of this PR is to disable WP Stash with a env variable temporarily, 
so there is no need to remove this mu plugin.  

Add new env variable WP_STASH_RUNNABLE & WpStash Class constants

- Messed up the bootstrap file a little bit and remove dropin file, if WP Stash shouldn't be runnable 
- Added new class constants to WpStash Class `SCHEDULED_PURGE_HOOK` & `DEFAULT_DROPIN_PATH`