### PR TITLE
Raise dependencies versions to be PHP 8 compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 #### dev-master
+* Raise dependency versions to be compatible with PHP 8
 
 #### 3.2.3
 * Fix: Typo in bypass logic, [#19](https://github.com/inpsyde/WP-Stash/issues/19)

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "issues": "https://github.com/inpsyde/WP-Stash/issues"
     },
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "tedivm/stash": "^0.17.1",
         "psr/log": "~1.0"
     },
@@ -37,6 +37,11 @@
     "autoload-dev": {
         "psr-4": {
             "Inpsyde\\WpStash\\Tests\\Unit\\": "tests/PHPUnit/Unit/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     },
     "require": {
         "php": ">=7.0",
-        "tedivm/stash": "^0.15",
+        "tedivm/stash": "^0.17.1",
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7",
+        "phpunit/phpunit": "^9.5",
         "brain/monkey": "^2",
-        "inpsyde/php-coding-standards": "^0.12",
-        "squizlabs/php_codesniffer": "~3.2.3"
+        "inpsyde/php-coding-standards": "^1.0",
+        "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {
         "psr-4": {

--- a/src/Admin/AdminBarMenu.php
+++ b/src/Admin/AdminBarMenu.php
@@ -1,10 +1,13 @@
-<?php declare(strict_types=1); // -*- coding: utf-8 -*-
+<?php
+// -*- coding: utf-8 -*-
+
+declare(strict_types=1);
+
 
 namespace Inpsyde\WpStash\Admin;
 
 class AdminBarMenu
 {
-
     const PARENT_ID = 'wp-stash';
 
     /**

--- a/src/Admin/CacheFlusher.php
+++ b/src/Admin/CacheFlusher.php
@@ -1,21 +1,24 @@
-<?php declare(strict_types=1); // -*- coding: utf-8 -*-
+<?php
+// -*- coding: utf-8 -*-
+
+declare(strict_types=1);
+
 
 namespace Inpsyde\WpStash\Admin;
 
 class CacheFlusher implements MenuItemProvider
 {
-
     const PURGE_ACTION = 'purge_cache';
 
     public function item(): MenuItem
     {
-        $referer = '&_wp_http_referer='.urlencode(wp_unslash($_SERVER['REQUEST_URI']));
+        $referer = '&_wp_http_referer=' . urlencode(wp_unslash($_SERVER['REQUEST_URI']));
 
         return new MenuItem(
             'wp-stash-flush',
             'Flush Object Cache',
             wp_nonce_url(
-                admin_url('admin-post.php?action='.self::PURGE_ACTION.$referer),
+                admin_url('admin-post.php?action=' . self::PURGE_ACTION . $referer),
                 self::PURGE_ACTION
             )
         );

--- a/src/Admin/Controller.php
+++ b/src/Admin/Controller.php
@@ -1,10 +1,13 @@
-<?php declare(strict_types=1); // -*- coding: utf-8 -*-
+<?php
+
+// -*- coding: utf-8 -*-
+
+declare(strict_types=1);
 
 namespace Inpsyde\WpStash\Admin;
 
 class Controller
 {
-
     /**
      * @var AdminBarMenu
      */
@@ -33,6 +36,6 @@ class Controller
     public function init()
     {
         add_action('admin_bar_menu', [$this->adminBarMenu, 'render']);
-        add_action('admin_post_'.CacheFlusher::PURGE_ACTION, [$this->cacheFlusher, 'flush_cache']);
+        add_action('admin_post_' . CacheFlusher::PURGE_ACTION, [$this->cacheFlusher, 'flush_cache']);
     }
 }

--- a/src/Admin/MenuItem.php
+++ b/src/Admin/MenuItem.php
@@ -1,10 +1,13 @@
-<?php declare(strict_types=1); // -*- coding: utf-8 -*-
+<?php
+// -*- coding: utf-8 -*-
+
+declare(strict_types=1);
+
 
 namespace Inpsyde\WpStash\Admin;
 
 class MenuItem
 {
-
     /**
      * @var string
      */

--- a/src/Admin/MenuItemProvider.php
+++ b/src/Admin/MenuItemProvider.php
@@ -1,9 +1,10 @@
-<?php // -*- coding: utf-8 -*-
+<?php
+
+// -*- coding: utf-8 -*-
 
 namespace Inpsyde\WpStash\Admin;
 
 interface MenuItemProvider
 {
-
     public function item(): MenuItem;
 }

--- a/src/Cli/WpCliCommand.php
+++ b/src/Cli/WpCliCommand.php
@@ -1,14 +1,15 @@
-<?php declare(strict_types=1); // -*- coding: utf-8 -*-
+<?php
+// -*- coding: utf-8 -*-
+
+declare(strict_types=1);
+
 
 namespace Inpsyde\WpStash\Cli;
 
 use Inpsyde\WpStash\WpStash;
-use WP_CLI;
+use \WP_CLI;
 
-// phpcs:disable Inpsyde.CodeQuality.LineLength.TooLong
-// phpcs:disable Inpsyde.CodeQuality.NoElse.ElseFound
-// phpcs:disable Inpsyde.CodeQuality.FunctionBodyStart.WrongForSingleLineDeclaration
-// phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration.NoArgumentType
+// phpcs:disable
 
 /**
  * Manage WP Stash.
@@ -25,7 +26,6 @@ use WP_CLI;
  */
 class WpCliCommand extends \WP_CLI_Command
 {
-
     /**
      * Flush the object cache.
      *
@@ -59,31 +59,31 @@ class WpCliCommand extends \WP_CLI_Command
         $result = file_put_contents(
             $scriptFilename,
             '<?php
-		if(! file_exists( "wp-load.php" ) ){
-			http_response_code( 500 );
-			echo "Could not find WordPress instance for object cache flushing via cURL request";
-			exit;
-		}
-		
-		// Skip stuff we do not need and could cause problems.
-		define( "SHORTINIT", true );
-		
-		require_once "wp-load.php";
-		
-		if( function_exists( "wp_cache_flush" ) ){
-			wp_cache_flush();
-			header("WP-Stash: Success");
-			echo "WP object cache flushed successfully";
-			exit;
-		}else{
-			http_response_code( 500 );
-			echo "WP loaded, now flushing object cache";
-			exit;
-		}
-		'
+            if (! file_exists("wp-load.php")) {
+                http_response_code(500);
+                echo "Could not find WordPress instance for object cache flushing via cURL request";
+                exit;
+            }
+
+        // Skip stuff we do not need and could cause problems.
+            define("SHORTINIT", true);
+
+            require_once "wp-load.php";
+
+            if (function_exists("wp_cache_flush")) {
+                wp_cache_flush();
+                header("WP-Stash: Success");
+                echo "WP object cache flushed successfully";
+                exit;
+            } else {
+                http_response_code(500);
+                echo "WP loaded, now flushing object cache";
+                exit;
+            }
+            '
         );
         if (! $result) {
-            WP_CLI::error('Could not place the temporary cache flusher script. Please review your file permissions');
+            WP_CLI::error('Could not place the temporary cache flusher script . Please review your file permissions');
         }
         // Fix potential SSL_shutdown:shutdown while in init in nginx
         add_filter('https_ssl_verify', '__return_false');
@@ -98,13 +98,13 @@ class WpCliCommand extends \WP_CLI_Command
             return;
         }
 
-        if ($response['response']['code'] === 200 && isset($response['headers']['WP-Stash'])) {
+        if ($response['response']['code'] === 200 && isset($response['headers']['WP - Stash'])) {
             WP_CLI::success($response['body']);
         } else {
             if ($response['response']['code'] !== 200) {
                 WP_CLI::error($response['body']);
             } else {
-                WP_CLI::error('Something unexpected happened during cache flushing. Maybe try to run this command with --skip-packages to prevent plugins/themes from interfering');
+                WP_CLI::error('Something unexpected happened during cache flushing . Maybe try to run this command with --skip - packages to prevent plugins / themes from interfering');
             }
         }
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); // -*- coding: utf-8 -*-
+<?php
+// -*- coding: utf-8 -*-
+
+declare(strict_types=1);
+
 
 namespace Inpsyde\WpStash;
 
@@ -12,7 +16,6 @@ use Stash\Interfaces\DriverInterface;
  */
 class Config
 {
-
     /**
      * @var string
      */
@@ -61,7 +64,8 @@ class Config
         }
 
         // phpcs:disable NeutronStandard.Functions.DisallowCallUserFunc.CallUserFunc
-        if (! in_array(DriverInterface::class, class_implements($className), true)
+        if (
+        ! in_array(DriverInterface::class, class_implements($className), true)
             || ! call_user_func([$className, 'isAvailable'])
         ) {
             return Ephemeral::class;
@@ -85,7 +89,7 @@ class Config
         return $this->usingMemoryCache;
     }
 
-    public function purgeInterval():int
+    public function purgeInterval(): int
     {
         return $this->purgeInterval;
     }

--- a/src/ConfigBuilder.php
+++ b/src/ConfigBuilder.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); // -*- coding: utf-8 -*-
+<?php
+// -*- coding: utf-8 -*-
+
+declare(strict_types=1);
+
 
 namespace Inpsyde\WpStash;
 
@@ -11,7 +15,6 @@ use Stash\Driver\Ephemeral;
  */
 final class ConfigBuilder
 {
-
     private const PURGE_INTERVAL = 3600 * 12;
     /**
      * Reads configuration data from the following constants:

--- a/src/Debug/ActionLogger.php
+++ b/src/Debug/ActionLogger.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
+<?php
+// -*- coding: utf-8 -*-
+
+declare(strict_types=1);
+
 
 namespace Inpsyde\WpStash\Debug;
 
@@ -28,5 +32,4 @@ class ActionLogger implements LoggerInterface
     {
         do_action(self::ACTION . strtolower($level), $message, $context + $this->additionalInfo);
     }
-
 }

--- a/src/Generator/CacheKeyGenerator.php
+++ b/src/Generator/CacheKeyGenerator.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1); // -*- coding: utf-8 -*-
+<?php
+
+// -*- coding: utf-8 -*-
+declare(strict_types=1);
 
 namespace Inpsyde\WpStash\Generator;
 
@@ -9,9 +12,8 @@ namespace Inpsyde\WpStash\Generator;
  */
 class CacheKeyGenerator implements KeyGen
 {
-
     public function create(string $key, string $group = 'default'): string
     {
-        return KeyGen::GLUE.implode(KeyGen::GLUE, [$group, $key]);
+        return KeyGen::GLUE . implode(KeyGen::GLUE, [$group, $key]);
     }
 }

--- a/src/Generator/KeyGen.php
+++ b/src/Generator/KeyGen.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); // -*- coding: utf-8 -*-
+<?php
+// -*- coding: utf-8 -*-
+
+declare(strict_types=1);
+
 
 namespace Inpsyde\WpStash\Generator;
 
@@ -9,7 +13,6 @@ namespace Inpsyde\WpStash\Generator;
  */
 interface KeyGen
 {
-
     const GLUE = '/';
 
     public function create(string $key, string $group): string;

--- a/src/Generator/MultisiteCacheKeyGenerator.php
+++ b/src/Generator/MultisiteCacheKeyGenerator.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); // -*- coding: utf-8 -*-
+<?php
+// -*- coding: utf-8 -*-
+
+declare(strict_types=1);
+
 
 namespace Inpsyde\WpStash\Generator;
 
@@ -9,7 +13,6 @@ namespace Inpsyde\WpStash\Generator;
  */
 class MultisiteCacheKeyGenerator implements MultisiteKeyGen
 {
-
     /**
      * @var int
      */
@@ -57,6 +60,6 @@ class MultisiteCacheKeyGenerator implements MultisiteKeyGen
             $parts[] = $this->blogId;
         }
 
-        return KeyGen::GLUE.implode(KeyGen::GLUE, $parts);
+        return KeyGen::GLUE . implode(KeyGen::GLUE, $parts);
     }
 }

--- a/src/Generator/MultisiteKeyGen.php
+++ b/src/Generator/MultisiteKeyGen.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); // -*- coding: utf-8 -*-
+<?php
+// -*- coding: utf-8 -*-
+
+declare(strict_types=1);
+
 
 namespace Inpsyde\WpStash\Generator;
 
@@ -9,7 +13,6 @@ namespace Inpsyde\WpStash\Generator;
  */
 interface MultisiteKeyGen extends KeyGen
 {
-
     public function addGlobalGroups($groups): array;
 
     public function switchToBlog(int $blogId): bool;

--- a/src/ObjectCacheProxy.php
+++ b/src/ObjectCacheProxy.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); // -*- coding: utf-8 -*-
+<?php
+// -*- coding: utf-8 -*-
+
+declare(strict_types=1);
+
 
 namespace Inpsyde\WpStash;
 

--- a/src/StashAdapter.php
+++ b/src/StashAdapter.php
@@ -1,4 +1,6 @@
-<?php // -*- coding: utf-8 -*-
+<?php
+
+// -*- coding: utf-8 -*-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash;
@@ -19,7 +21,6 @@ use Stash\Pool;
  */
 class StashAdapter
 {
-
     /**
      * @var int
      */

--- a/src/WpStash.php
+++ b/src/WpStash.php
@@ -1,4 +1,8 @@
-<?php declare(strict_types=1); // -*- coding: utf-8 -*-
+<?php
+
+// -*- coding: utf-8 -*-
+
+declare(strict_types=1);
 
 namespace Inpsyde\WpStash;
 
@@ -15,7 +19,6 @@ use Stash\Pool;
  */
 final class WpStash
 {
-
     /**
      * @var Config
      */
@@ -53,7 +56,7 @@ final class WpStash
         static $instance;
         if (! $instance) {
             $config = ConfigBuilder::create();
-            $instance = new self(__DIR__.'/../dropin/object-cache.php', $config);
+            $instance = new self(__DIR__ . '/../dropin/object-cache.php', $config);
             $instance->init();
         }
 
@@ -122,7 +125,8 @@ final class WpStash
          * For increased performance, WP Stash will automatically wrap the selected
          * backend into a staggered cache combined with the Ephemeral driver.
          */
-        if ($this->config->usingMemoryCache()
+        if (
+            $this->config->usingMemoryCache()
             && !$driver instanceof Composite
             && !$driver instanceof Ephemeral
         ) {
@@ -200,15 +204,17 @@ final class WpStash
 
     private function ensureDropIn(): bool
     {
-        $target = WP_CONTENT_DIR.DIRECTORY_SEPARATOR.$this->dropinName;
+        $target = WP_CONTENT_DIR . DIRECTORY_SEPARATOR . $this->dropinName;
         if (file_exists($target)) {
             return true;
         }
         $dropIn = sprintf(
             <<<'PHPCODE'
-<?php declare(strict_types=1);
+<?php
 
-if(!file_exists('%1$s')){
+declare(strict_types=1);
+
+if (!file_exists('%1$s')) {
     unlink(__FILE__);
     return;
 }
@@ -227,9 +233,9 @@ PHPCODE
     private function isWpCli(): bool
     {
         return
-            defined('WP_CLI')
-            && WP_CLI
-            && class_exists(\WP_CLI::class)
-            && class_exists(\WP_CLI_Command::class);
+        defined('WP_CLI')
+        && WP_CLI
+        && class_exists(\WP_CLI::class)
+        && class_exists(\WP_CLI_Command::class);
     }
 }

--- a/tests/PHPUnit/Unit/AbstractUnitTestcase.php
+++ b/tests/PHPUnit/Unit/AbstractUnitTestcase.php
@@ -13,7 +13,7 @@ abstract class AbstractUnitTestcase extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         Monkey\setUp();
@@ -24,7 +24,7 @@ abstract class AbstractUnitTestcase extends TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Monkey\tearDown();
         parent::tearDown();

--- a/tests/PHPUnit/Unit/Generator/CacheKeyGeneratorTest.php
+++ b/tests/PHPUnit/Unit/Generator/CacheKeyGeneratorTest.php
@@ -14,6 +14,6 @@ class CacheKeyGeneratorTest extends AbstractUnitTestcase
 
         $expectedKey = 'foo';
 
-        static::assertContains($expectedKey, $testee->create($expectedKey));
+        static::assertStringContainsString($expectedKey, $testee->create($expectedKey));
     }
 }

--- a/tests/PHPUnit/Unit/Generator/MultisiteCacheKeyGeneratorTest.php
+++ b/tests/PHPUnit/Unit/Generator/MultisiteCacheKeyGeneratorTest.php
@@ -17,9 +17,9 @@ class MultisiteCacheKeyGeneratorTest extends AbstractUnitTestcase
         $testee = new MultisiteCacheKeyGenerator($expectedBlogId);
         $result = $testee->create($expectedKey, $expectedGroup);
 
-        static::assertContains($expectedKey, $result);
-        static::assertContains($expectedGroup, $result);
-        static::assertContains((string)$expectedBlogId, $result);
+        static::assertStringContainsString($expectedKey, $result);
+        static::assertStringContainsString($expectedGroup, $result);
+        static::assertStringContainsString((string)$expectedBlogId, $result);
     }
 
     public function testAddGlobalGroup()


### PR DESCRIPTION
- raise tedivm/stash to ^0.17.1

dev dependencies:
- raise phpunit/phpunit to ^9.5
- raise inpsyde/php-coding-standards to ^1.0
- raise squizlabs/php_codesniffer to ^3.6
- adapt PHPUnit ::assertContains() to ::assertStringContainsString()

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

Fixes #21

