### PR TITLE
Fix get multiple method

### DIFF
--- a/dropin/object-cache.php
+++ b/dropin/object-cache.php
@@ -304,7 +304,8 @@ function wp_cache_reset()
  * @param string $group Optional. Where the cache contents are grouped. Default empty.
  * @param bool   $force Optional. Whether to force an update of the local cache
  *                      from the persistent cache. Default false.
- * @return array Array of values organized into groups.
+ * @return array Array of return values, grouped by key. Each value is either
+ *               the cache contents on success, or false on failure.
  */
 function wp_cache_get_multiple($keys, $group = '', $force = false)
 {

--- a/src/ObjectCacheProxy.php
+++ b/src/ObjectCacheProxy.php
@@ -462,6 +462,7 @@ class ObjectCacheProxy
      */
     public function get_multiple($keys, $group = '', $force = false)
     {
+        $keys = array_unique($keys);
         $cache_keys = [];
         foreach ($keys as $key) {
             $cache_keys[] = $this->key_gen->create((string) $key, (string) $group);

--- a/src/ObjectCacheProxy.php
+++ b/src/ObjectCacheProxy.php
@@ -462,6 +462,13 @@ class ObjectCacheProxy
      */
     public function get_multiple($keys, $group = '', $force = false)
     {
-        return $this->choose_pool($group)->getMultiple($keys);
+        $cache_keys = [];
+        foreach ($keys as $key) {
+            $cache_keys[] = $this->key_gen->create((string) $key, (string) $group);
+        }
+
+        $items = $this->choose_pool($group)->getMultiple($cache_keys);
+
+        return array_combine($keys, $items);
     }
 }

--- a/tests/PHPUnit/Unit/ObjectCacheProxyTest.php
+++ b/tests/PHPUnit/Unit/ObjectCacheProxyTest.php
@@ -174,7 +174,7 @@ class ObjectCacheProxyTest extends AbstractUnitTestcase
                 'key_2' => 'data_key_2',
             ],
             $testee->get_multiple(
-                ['key_1', 'key_2'],
+                ['key_1', 'key_2', 'key_2'],
                 'my_group'
             )
         );

--- a/tests/PHPUnit/Unit/ObjectCacheProxyTest.php
+++ b/tests/PHPUnit/Unit/ObjectCacheProxyTest.php
@@ -4,10 +4,13 @@ namespace Inpsyde\WpStash\Tests\Unit;
 
 use Brain\Monkey\Functions;
 use Inpsyde\WpStash\Generator\KeyGen;
+use Inpsyde\WpStash\Generator\MultisiteCacheKeyGenerator;
 use Inpsyde\WpStash\Generator\MultisiteKeyGen;
 use Inpsyde\WpStash\ObjectCacheProxy;
 use Inpsyde\WpStash\StashAdapter;
 use Mockery\MockInterface;
+use Stash\Driver\Ephemeral;
+use Stash\Pool;
 
 class ObjectCacheProxyTest extends AbstractUnitTestcase
 {
@@ -141,6 +144,40 @@ class ObjectCacheProxyTest extends AbstractUnitTestcase
         $testee = new ObjectCacheProxy($nonPersistentPool, $persistentPool, $keyGen);
         $result = $testee->add_non_persistent_groups($nonPersistentGroups);
         $this->assertSame(array_fill_keys($nonPersistentGroups, true), $result);
+    }
+
+    public function test_get_multiple(): void
+    {
+        Functions\expect('wp_suspend_cache_addition')
+            ->twice()
+            ->andReturn(false);
+
+        $testee = new ObjectCacheProxy(
+            new StashAdapter(
+                new Pool(
+                    new Ephemeral()
+                )
+            ),
+            new StashAdapter(
+                new Pool(
+                    new Ephemeral()
+                )
+            ),
+            new MultisiteCacheKeyGenerator(1)
+        );
+
+        $testee->add('key_1', 'data_key_1', 'my_group');
+        $testee->add('key_2', 'data_key_2', 'my_group');
+        $this->assertSame(
+            [
+                'key_1' => 'data_key_1',
+                'key_2' => 'data_key_2',
+            ],
+            $testee->get_multiple(
+                ['key_1', 'key_2'],
+                'my_group'
+            )
+        );
     }
 
     public function default_test_data()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


**What is the current behavior?** (You can also link to an open issue here)
The current `wp_cache_get_multiple` and `\Inpsyde\WpStash\ObjectCacheProxy::get_multiple` don't work as expected.
The problem is when we add the item to the cache we generate an item key with `\Inpsyde\WpStash\Generator\KeyGen` but we completely ignore this when retrieving multiple values. So the cache is always missing.

**What is the new behavior (if this is a feature change)?**
The current fix allows us to retrieve multiple values which were added before.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.



**Other information**:
Unrelated but with 6.0.0 we have `wp_cache_set_multiple`. It should be included in the library as well.
