### PR TITLE
Remove utf8 encoding comments

### DIFF
--- a/src/Admin/AdminBarMenu.php
+++ b/src/Admin/AdminBarMenu.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash\Admin;

--- a/src/Admin/AdminBarMenu.php
+++ b/src/Admin/AdminBarMenu.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 
 declare(strict_types=1);
 

--- a/src/Admin/CacheFlusher.php
+++ b/src/Admin/CacheFlusher.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash\Admin;

--- a/src/Admin/CacheFlusher.php
+++ b/src/Admin/CacheFlusher.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 
 declare(strict_types=1);
 

--- a/src/Admin/Controller.php
+++ b/src/Admin/Controller.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash\Admin;

--- a/src/Admin/Controller.php
+++ b/src/Admin/Controller.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 
 declare(strict_types=1);
 

--- a/src/Admin/MenuItem.php
+++ b/src/Admin/MenuItem.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash\Admin;

--- a/src/Admin/MenuItem.php
+++ b/src/Admin/MenuItem.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 
 declare(strict_types=1);
 

--- a/src/Admin/MenuItemProvider.php
+++ b/src/Admin/MenuItemProvider.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Inpsyde\WpStash\Admin;
 
 interface MenuItemProvider

--- a/src/Admin/MenuItemProvider.php
+++ b/src/Admin/MenuItemProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Inpsyde\WpStash\Admin;
 
 interface MenuItemProvider

--- a/src/Admin/MenuItemProvider.php
+++ b/src/Admin/MenuItemProvider.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 
 namespace Inpsyde\WpStash\Admin;
 

--- a/src/Cli/WpCliCommand.php
+++ b/src/Cli/WpCliCommand.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 
 declare(strict_types=1);
 

--- a/src/Cli/WpCliCommand.php
+++ b/src/Cli/WpCliCommand.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash\Cli;

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 
 declare(strict_types=1);
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash;

--- a/src/ConfigBuilder.php
+++ b/src/ConfigBuilder.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 
 declare(strict_types=1);
 

--- a/src/ConfigBuilder.php
+++ b/src/ConfigBuilder.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash;

--- a/src/Debug/ActionLogger.php
+++ b/src/Debug/ActionLogger.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 
 declare(strict_types=1);
 

--- a/src/Debug/ActionLogger.php
+++ b/src/Debug/ActionLogger.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash\Debug;

--- a/src/Generator/KeyGen.php
+++ b/src/Generator/KeyGen.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash\Generator;

--- a/src/Generator/KeyGen.php
+++ b/src/Generator/KeyGen.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 
 declare(strict_types=1);
 

--- a/src/Generator/MultisiteCacheKeyGenerator.php
+++ b/src/Generator/MultisiteCacheKeyGenerator.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash\Generator;

--- a/src/Generator/MultisiteCacheKeyGenerator.php
+++ b/src/Generator/MultisiteCacheKeyGenerator.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 
 declare(strict_types=1);
 

--- a/src/Generator/MultisiteKeyGen.php
+++ b/src/Generator/MultisiteKeyGen.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash\Generator;

--- a/src/Generator/MultisiteKeyGen.php
+++ b/src/Generator/MultisiteKeyGen.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 
 declare(strict_types=1);
 

--- a/src/ObjectCacheProxy.php
+++ b/src/ObjectCacheProxy.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 
 declare(strict_types=1);
 

--- a/src/ObjectCacheProxy.php
+++ b/src/ObjectCacheProxy.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash;

--- a/src/StashAdapter.php
+++ b/src/StashAdapter.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash;

--- a/src/WpStash.php
+++ b/src/WpStash.php
@@ -1,6 +1,5 @@
 <?php
 
-// -*- coding: utf-8 -*-
 
 declare(strict_types=1);
 

--- a/src/WpStash.php
+++ b/src/WpStash.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace Inpsyde\WpStash;

--- a/tests/PHPUnit/Unit/AbstractUnitTestcase.php
+++ b/tests/PHPUnit/Unit/AbstractUnitTestcase.php
@@ -1,5 +1,4 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
-
+<?php declare(strict_types=1); 
 namespace Inpsyde\WpStash\Tests\Unit;
 
 use Brain\Monkey;

--- a/tests/PHPUnit/Unit/AbstractUnitTestcase.php
+++ b/tests/PHPUnit/Unit/AbstractUnitTestcase.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1); 
+<?php
+
+declare(strict_types=1);
+
 namespace Inpsyde\WpStash\Tests\Unit;
 
 use Brain\Monkey;

--- a/tests/PHPUnit/Unit/ConfigBuilderTest.php
+++ b/tests/PHPUnit/Unit/ConfigBuilderTest.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1); 
+<?php
+
+declare(strict_types=1);
+
 namespace Inpsyde\WpStash\Tests\Unit;
 
 use Inpsyde\WpStash\Config;

--- a/tests/PHPUnit/Unit/ConfigBuilderTest.php
+++ b/tests/PHPUnit/Unit/ConfigBuilderTest.php
@@ -1,5 +1,4 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
-
+<?php declare(strict_types=1); 
 namespace Inpsyde\WpStash\Tests\Unit;
 
 use Inpsyde\WpStash\Config;

--- a/tests/PHPUnit/Unit/ConfigTest.php
+++ b/tests/PHPUnit/Unit/ConfigTest.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1); 
+<?php
+
+declare(strict_types=1);
+
 namespace Inpsyde\WpStash\Tests\Unit;
 
 use Inpsyde\WpStash\Config;

--- a/tests/PHPUnit/Unit/ConfigTest.php
+++ b/tests/PHPUnit/Unit/ConfigTest.php
@@ -1,5 +1,4 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
-
+<?php declare(strict_types=1); 
 namespace Inpsyde\WpStash\Tests\Unit;
 
 use Inpsyde\WpStash\Config;

--- a/tests/PHPUnit/Unit/ObjectCacheProxyTest.php
+++ b/tests/PHPUnit/Unit/ObjectCacheProxyTest.php
@@ -1,5 +1,4 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
-
+<?php declare(strict_types=1); 
 namespace Inpsyde\WpStash\Tests\Unit;
 
 use Brain\Monkey\Functions;

--- a/tests/PHPUnit/Unit/ObjectCacheProxyTest.php
+++ b/tests/PHPUnit/Unit/ObjectCacheProxyTest.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1); 
+<?php
+
+declare(strict_types=1);
+
 namespace Inpsyde\WpStash\Tests\Unit;
 
 use Brain\Monkey\Functions;

--- a/tests/PHPUnit/Unit/StashAdapterTest.php
+++ b/tests/PHPUnit/Unit/StashAdapterTest.php
@@ -1,5 +1,4 @@
-<?php declare(strict_types=1); # -*- coding: utf-8 -*-
-
+<?php declare(strict_types=1); 
 namespace Inpsyde\WpStash\Tests\Unit;
 
 use Inpsyde\WpStash\StashAdapter;

--- a/tests/PHPUnit/Unit/StashAdapterTest.php
+++ b/tests/PHPUnit/Unit/StashAdapterTest.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1); 
+<?php
+
+declare(strict_types=1);
+
 namespace Inpsyde\WpStash\Tests\Unit;
 
 use Inpsyde\WpStash\StashAdapter;

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 putenv('TESTS_PATH='.__DIR__);
 putenv('LIBRARY_PATH='.dirname(__DIR__));
 $vendor = dirname(dirname(dirname(__FILE__))).'/vendor/';

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -1,4 +1,4 @@
-<?php # -*- coding: utf-8 -*-
+<?php
 putenv('TESTS_PATH='.__DIR__);
 putenv('LIBRARY_PATH='.dirname(__DIR__));
 $vendor = dirname(dirname(dirname(__FILE__))).'/vendor/';

--- a/wp-stash.php
+++ b/wp-stash.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Plugin Name: WP Stash
  * Plugin URI:

--- a/wp-stash.php
+++ b/wp-stash.php
@@ -1,4 +1,4 @@
-<?php # -*- coding: utf-8 -*-
+<?php
 
 /**
  * Plugin Name: WP Stash


### PR DESCRIPTION
Removes the `-*- coding: utf-8 -*-` comments for the new Sniff in our PHP Coding standards:
https://github.com/inpsyde/php-coding-standards/pull/77

Context: https://inpsyde.slack.com/archives/C03LQSP85UM/p1702573675052719


