### PR TITLE
fix: update deprecated filter constant

### DIFF
--- a/src/Admin/CacheFlusher.php
+++ b/src/Admin/CacheFlusher.php
@@ -33,7 +33,7 @@ class CacheFlusher implements MenuItemProvider
      */
     public function flush_cache()
     {
-        $wpNonce = filter_input(INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING);
+        $wpNonce = filter_input(INPUT_GET, '_wpnonce', FILTER_SANITIZE_SPECIAL_CHARS);
         if (!$wpNonce || !wp_verify_nonce($wpNonce, self::PURGE_ACTION)) {
             wp_nonce_ays('');
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Compatibility fix


**What is the current behavior?** (You can also link to an open issue here)
Usage of the `FILTER_SANITIZE_STRING` constant, which is deprecated as of PHP 8.1.0


**What is the new behavior (if this is a feature change)?**
Switch from `FILTER_SANITIZE_STRING` to `FILTER_SANITIZE_SPECIAL_CHARS`


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
